### PR TITLE
DBeaver integration with extra rendering on some commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,20 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.22</version>
+                <version>1.18.24</version>
                 <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
-                <version>3.6.3</version>
+                <version>4.3.1</version>
             </dependency>
 
             <dependency>

--- a/redis-jdbc-driver-core/pom.xml
+++ b/redis-jdbc-driver-core/pom.xml
@@ -19,8 +19,11 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/ColumnConverter.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/ColumnConverter.java
@@ -1,0 +1,72 @@
+package com.itmuch.redis.jdbc;
+
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Getter
+@SuperBuilder
+public class ColumnConverter<R> {
+
+    public static final ColumnConverter TTL_CONVERTER = ColumnConverter.<Timestamp>builder()
+           .columnName("TIMESTAMP")
+           .targetType(Timestamp.class)
+           .columnTypeName(Types.TIMESTAMP)
+           .converter(str -> {
+               Long number = Long.parseLong(str);
+               if (number == -1 || number == -2) {
+                   return null;
+               }
+               LocalDateTime ldt = LocalDateTime.now().plus(number, ChronoUnit.SECONDS).truncatedTo(ChronoUnit.SECONDS);
+               return Timestamp.valueOf(ldt);
+           })
+           .build();
+
+    public static final ColumnConverter PTTL_CONVERTER = ColumnConverter.<Timestamp>builder()
+            .columnName("TIMESTAMP")
+            .targetType(Timestamp.class)
+            .columnTypeName(Types.TIMESTAMP)
+            .converter(str -> {
+                Long number = Long.parseLong(str);
+                if (number == -1 || number == -2) {
+                    return null;
+                }
+                LocalDateTime ldt = LocalDateTime.now().plus(number, ChronoUnit.MILLIS).truncatedTo(ChronoUnit.SECONDS);
+                return Timestamp.valueOf(ldt);
+            })
+            .build();
+
+    protected static final Map<String, ColumnConverter> COMMAND_CONVERTERS = Utils.imapOf(
+            "TTL", TTL_CONVERTER,
+            "PTTL", PTTL_CONVERTER
+                                                                                         );
+
+    Function<String, R> converter;
+
+    BiFunction<String, String[], R> inputAwareConverter;
+
+    Class<R> targetType;
+
+    Integer columnTypeName;
+
+    String columnName;
+
+    public BiFunction<String, String[], R> getInputAwareConverter() {
+        if (inputAwareConverter == null) {
+            inputAwareConverter = ((String value, String[] args) -> this.converter.apply(value));
+        }
+        return inputAwareConverter;
+    }
+
+}

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/HashRedisResultSet.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/HashRedisResultSet.java
@@ -1,0 +1,44 @@
+package com.itmuch.redis.jdbc;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.function.Function;
+
+public class HashRedisResultSet extends RedisResultSet {
+    private final static Logger LOGGER = new Logger(HashRedisResultSet.class);
+
+    private final String[] keys;
+    private final String[] values;
+
+    public HashRedisResultSet(String[] result, final Statement owningStatement, String[] commandArguments, HashResultConverter converter) throws SQLException {
+        super(converter.keyExtractor.apply(result, commandArguments), owningStatement, commandArguments, null);
+        this.keys = converter.keyExtractor.apply(result, commandArguments);
+        this.values = converter.valueExtractor.apply(result, commandArguments);
+        if (keys.length != values.length) {
+            throw new SQLException("Result cannot be converted");
+        }
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        return new HashRedisResultSetMetaData(Arrays.asList("KEY", "VALUE"));
+    }
+
+    @Override
+    protected <T> T getColumnIndexWithDefault(int columnIndex, T nullDefault, Function<String, T> converter) throws SQLException {
+        String str;
+        if (columnIndex == 1) {
+            str = keys[getPosition()];
+        } else if (columnIndex == 2) {
+            str = values[getPosition()];
+        } else {
+            throw new SQLException("Invalid columnIndex " + columnIndex);
+        }
+        if (str == null) {
+            return nullDefault;
+        }
+        return converter.apply(str);
+    }
+}

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/HashResultConverter.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/HashResultConverter.java
@@ -1,0 +1,66 @@
+package com.itmuch.redis.jdbc;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.ArrayUtils;
+
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Getter
+@SuperBuilder
+public class HashResultConverter {
+
+    public static final HashResultConverter KEY_EVEN_VALUE_ODD_ARRAY = HashResultConverter.builder()
+           .keyExtractor(((String[] results, String[] args) -> {
+                return subArray(results, true);
+            }))
+           .valueExtractor(((String[] results, String[] args) -> {
+               return subArray(results, false);
+            }))
+           .name("KEY_EVEN_VALUE_ODD_ARRAY")
+                                                                                          .build();
+
+    public static final HashResultConverter ARGS_ARE_KEY_NAMES = HashResultConverter.builder()
+           .keyExtractor(((String[] results, String[] args) -> ArrayUtils.subarray(args, 1, args.length)))
+           .valueExtractor(((String[] results, String[] args) -> results))
+           .name("ARGS_ARE_KEY_NAMES")
+            .build();
+
+
+    protected static final Map<String, HashResultConverter> COMMAND_CONVERTERS = Utils.imapOf(
+            "HGETALL", KEY_EVEN_VALUE_ODD_ARRAY,
+            "HMGET", ARGS_ARE_KEY_NAMES,
+            "HGET", ARGS_ARE_KEY_NAMES
+                                                                                               );
+
+    BiFunction<String[], String[], String[]> keyExtractor;
+    BiFunction<String[], String[], String[]> valueExtractor;
+
+    String name;
+
+    private static String[] subArray(String[] source, boolean even) {
+        if (source.length %2 != 0) {
+            throw new IllegalArgumentException("Expecting array to be kw pairs");
+        }
+        String[] result = new String[source.length/2];
+        for (int i = 0; i < source.length; i++) {
+            boolean isEven = i %2 == 0;
+            if (even && isEven) {
+                result[i/2] = source[i];
+            } else if(!even && !isEven) {
+                result[(i-1)/2] = source[i];
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().toString() + '@' + name;
+    }
+}

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisClient.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisClient.java
@@ -10,4 +10,8 @@ public interface RedisClient {
     int getDbIndex() throws SQLException;
 
     void close();
+
+    default boolean hasMultiDb() {
+        return true;
+    }
 }

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisClient.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisClient.java
@@ -7,5 +7,7 @@ public interface RedisClient {
 
     void select(int dbIndex) throws SQLException;
 
+    int getDbIndex() throws SQLException;
+
     void close();
 }

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisClient.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisClient.java
@@ -1,6 +1,9 @@
 package com.itmuch.redis.jdbc;
 
 import java.sql.SQLException;
+import java.util.Map;
+
+import com.itmuch.redis.jdbc.conf.Feature;
 
 public interface RedisClient {
     String[] sendCommand(String sql) throws SQLException;
@@ -10,6 +13,8 @@ public interface RedisClient {
     int getDbIndex() throws SQLException;
 
     void close();
+
+    Map<Feature, Boolean> getFeatureMap();
 
     default boolean hasMultiDb() {
         return true;

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisConnection.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisConnection.java
@@ -11,11 +11,8 @@ public class RedisConnection implements Connection {
     private final RedisClient redisClient;
     private final Properties properties;
 
-    private String dbIndex;
-
-    public RedisConnection(RedisClient redisClient, String dbIndex, Properties properties) {
+    public RedisConnection(RedisClient redisClient, Properties properties) {
         this.redisClient = redisClient;
-        this.dbIndex = dbIndex;
         this.properties = properties;
     }
 
@@ -82,7 +79,7 @@ public class RedisConnection implements Connection {
 
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
-        return new RedisDatabaseMetadata(this, this.dbIndex);
+        return new RedisDatabaseMetadata(this, redisClient.getDbIndex());
     }
 
     @Override
@@ -300,8 +297,6 @@ public class RedisConnection implements Connection {
             this.checkClosed();
 
             this.redisClient.select(Integer.parseInt(schema));
-
-            this.dbIndex = schema;
         }
     }
 
@@ -309,8 +304,9 @@ public class RedisConnection implements Connection {
     public String getSchema() throws SQLException {
         synchronized (RedisConnection.class) {
             this.checkClosed();
-            LOGGER.log("getSchema() = %s", this.dbIndex);
-            return this.dbIndex;
+            int dbIndex = redisClient.getDbIndex();
+            LOGGER.log("getSchema() = %s", dbIndex);
+            return String.valueOf(dbIndex);
         }
     }
 

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisConnection.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisConnection.java
@@ -27,9 +27,8 @@ public class RedisConnection implements Connection {
 
     @Override
     public PreparedStatement prepareStatement(String sql) throws SQLException {
-        // TODO 暂不实现，感觉意义不大，未来看是否需要实现
-        LOGGER.log("prepareStatement not implemented");
-        throw new SQLFeatureNotSupportedException("prepareStatement not implemented");
+        this.checkClosed();
+        return new RedisPreparedStatement(sql, this, this.redisClient);
     }
 
     @Override
@@ -79,7 +78,7 @@ public class RedisConnection implements Connection {
 
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
-        return new RedisDatabaseMetadata(this, redisClient.getDbIndex());
+        return new RedisDatabaseMetadata(this, redisClient.getDbIndex(), redisClient.hasMultiDb());
     }
 
     @Override

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisDatabaseMetadata.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisDatabaseMetadata.java
@@ -11,9 +11,9 @@ public class RedisDatabaseMetadata implements DatabaseMetaData {
     private final static Logger LOGGER = new Logger(RedisDatabaseMetadata.class);
 
     private final RedisConnection connection;
-    private final String dbIndex;
+    private final int dbIndex;
 
-    public RedisDatabaseMetadata(RedisConnection connection, String dbIndex) {
+    public RedisDatabaseMetadata(RedisConnection connection, int dbIndex) {
         this.connection = connection;
         this.dbIndex = dbIndex;
     }
@@ -940,7 +940,7 @@ public class RedisDatabaseMetadata implements DatabaseMetaData {
             return this.getSchemas();
         }
 
-        schemaPattern = Utils.isNumber(schemaPattern) ? schemaPattern : dbIndex;
+        schemaPattern = Utils.isNumber(schemaPattern) ? schemaPattern : String.valueOf(dbIndex);
 
         return new RedisResultSet(new String[]{schemaPattern}, this.connection.createStatement());
     }

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisDatabaseMetadata.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisDatabaseMetadata.java
@@ -13,9 +13,12 @@ public class RedisDatabaseMetadata implements DatabaseMetaData {
     private final RedisConnection connection;
     private final int dbIndex;
 
-    public RedisDatabaseMetadata(RedisConnection connection, int dbIndex) {
+    private boolean hasMultipleDb;
+
+    public RedisDatabaseMetadata(RedisConnection connection, int dbIndex, boolean hasMultipleDb) {
         this.connection = connection;
         this.dbIndex = dbIndex;
+        this.hasMultipleDb = hasMultipleDb;
     }
 
     @Override
@@ -662,9 +665,14 @@ public class RedisDatabaseMetadata implements DatabaseMetaData {
         ResultSet rs;
         Statement statement = connection.createStatement();
 
-        String[] databases = IntStream.range(0, 16)
-                .mapToObj(i -> i + "")
-                .toArray(String[]::new);
+        String[] databases;
+        if (hasMultipleDb) {
+            databases = IntStream.range(0, 16)
+                                          .mapToObj(i -> i + "")
+                                          .toArray(String[]::new);
+        } else {
+            databases = new String[]{"0"};
+        }
         rs = new RedisResultSet(databases, statement);
         return rs;
     }

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisPreparedStatement.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisPreparedStatement.java
@@ -1,0 +1,224 @@
+package com.itmuch.redis.jdbc;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RedisPreparedStatement extends RedisStatement implements PreparedStatement {
+
+    private final static Logger LOGGER = new Logger(RedisPreparedStatement.class);
+
+    private final String sql;
+
+    private final Map<Integer, Object> params = new HashMap<>();
+
+    public RedisPreparedStatement(String sql, RedisConnection connection, RedisClient client) {
+        super(connection, client);
+        this.sql = sql;
+    }
+
+    @Override
+    public ResultSet executeQuery() throws SQLException {
+        LOGGER.log("executeQuery(%s, %s)", sql, params);
+        return super.executeQuery(sql);
+    }
+
+    @Override public int executeUpdate() throws SQLException {
+        return 0;
+    }
+
+    @Override public void setNull(int parameterIndex, int sqlType) throws SQLException {
+
+    }
+
+    @Override public void setBoolean(int parameterIndex, boolean x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setByte(int parameterIndex, byte x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setShort(int parameterIndex, short x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setInt(int parameterIndex, int x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setLong(int parameterIndex, long x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setFloat(int parameterIndex, float x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setDouble(int parameterIndex, double x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+        params.put(parameterIndex, x);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String x) throws SQLException {
+        params.put(parameterIndex, x);
+    }
+
+    @Override public void setBytes(int parameterIndex, byte[] x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setDate(int parameterIndex, Date x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setTime(int parameterIndex, Time x) throws SQLException {
+        params.put(parameterIndex, x);
+    }
+
+    @Override public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override public void clearParameters() throws SQLException {
+
+    }
+
+    @Override public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+
+    }
+
+    @Override public void setObject(int parameterIndex, Object x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public boolean execute() throws SQLException {
+        executeQuery();
+        return true;
+    }
+
+    @Override public void addBatch() throws SQLException {
+
+    }
+
+    @Override public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+
+    }
+
+    @Override public void setRef(int parameterIndex, Ref x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setBlob(int parameterIndex, Blob x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setClob(int parameterIndex, Clob x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setArray(int parameterIndex, Array x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public ResultSetMetaData getMetaData() throws SQLException {
+        return getResultSet().getMetaData();
+    }
+
+    @Override public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+
+    }
+
+    @Override public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+
+    }
+
+    @Override public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+
+    }
+
+    @Override public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+
+    }
+
+    @Override public void setURL(int parameterIndex, URL x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public ParameterMetaData getParameterMetaData() throws SQLException {
+        return null;
+    }
+
+    @Override public void setRowId(int parameterIndex, RowId x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setNString(int parameterIndex, String value) throws SQLException {
+
+    }
+
+    @Override public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+
+    }
+
+    @Override public void setNClob(int parameterIndex, NClob value) throws SQLException {
+
+    }
+
+    @Override public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+
+    }
+
+    @Override public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+
+    }
+
+    @Override public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+
+    }
+
+    @Override public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+
+    }
+
+    @Override public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+
+    }
+
+    @Override public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {params.put(parameterIndex, x);}
+
+    @Override public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+
+    }
+
+    @Override public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+
+    }
+
+    @Override public void setClob(int parameterIndex, Reader reader) throws SQLException {
+
+    }
+
+    @Override public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+
+    }
+
+    @Override public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+
+    }
+}

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisResultSet.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisResultSet.java
@@ -5,22 +5,64 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.sql.*;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class RedisResultSet implements ResultSet {
     private final static Logger LOGGER = new Logger(RedisResultSet.class);
 
+    public static final String DEFAULT_COLUMN_NAME = "RESULTS";
+    public static final Integer DEFAULT_COLUMN_INDEX = 1;
+
     private final String[] result;
+
+
+    private final String[] commandArguments;
+
+    private final ColumnConverter columnConverter;
+
+    private final Map<String, Integer> columnIndexes;
     private final Statement owningStatement;
+
 
     private int position = -1;
     private boolean isClosed = false;
 
     public RedisResultSet(final String[] result, final Statement owningStatement) {
+        this(result, owningStatement, null, null);
+    }
+
+    public RedisResultSet(final String[] result, final Statement owningStatement, String[] commandArguments, ColumnConverter converter) {
         this.result = result;
         this.owningStatement = owningStatement;
+        this.commandArguments = commandArguments;
+        this.columnConverter = converter;
+        if (converter == null) {
+            columnIndexes = Utils.imapOf(DEFAULT_COLUMN_NAME, DEFAULT_COLUMN_INDEX);
+        } else {
+            columnIndexes = Utils.imapOf(DEFAULT_COLUMN_NAME, DEFAULT_COLUMN_INDEX, converter.columnName.toUpperCase(), 2);
+        }
     }
 
     private void checkClosed() throws SQLException {
@@ -42,6 +84,10 @@ public class RedisResultSet implements ResultSet {
         }
     }
 
+    public int getPosition() {
+        return position;
+    }
+
     @Override
     public void close() throws SQLException {
         LOGGER.log("ResultSet close");
@@ -54,116 +100,85 @@ public class RedisResultSet implements ResultSet {
         return result[position] == null;
     }
 
+    protected <T> T getColumnIndexWithDefault(int columnIndex, T nullDefault, Function<String, T> converter) throws SQLException {
+        this.checkClosed();
+        if (columnIndex < 1 && columnIndex > columnIndexes.size()) {
+            throw new SQLException("Invalid column index " + columnIndex);
+        }
+        String s = result[position];
+        if (s == null) {
+            return nullDefault;
+        }
+        if (columnIndex != DEFAULT_COLUMN_INDEX || columnIndex < DEFAULT_COLUMN_INDEX) { //generated column
+            return (T) columnConverter.getInputAwareConverter().apply(s, commandArguments); //possible classcast
+        }
+        try {
+            return converter.apply(s);
+        } catch (RuntimeException e) {
+            throw new SQLException(e.getMessage(), e);
+        }
+    }
+
     @Override
     public String getString(int columnIndex) throws SQLException {
-        this.checkClosed();
         LOGGER.log("getString(%s)", columnIndex);
-        return result[position];
+        return getColumnIndexWithDefault(columnIndex, null, String::toString);
     }
 
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
         this.checkClosed();
 
-        String r = this.getString(0);
-
-        if ("0".equals(r) || "false".equals(r)) {
-            return false;
-        } else if ("1".equals(r) || "true".equals(r)) {
-            return true;
-        } else {
-            LOGGER.log("Cannot convert " + r + " into a boolean.");
-            throw new SQLException("Cannot convert " + r + " into a boolean.");
-        }
+        return getColumnIndexWithDefault(columnIndex, null, s -> {
+            if (StringUtils.equalsAny(s, "0", "false")) {
+                return false;
+            } else if (StringUtils.equalsAny(s, "1", "true")) {
+                return true;
+            } else {
+                LOGGER.log("Cannot convert " + s + " into a boolean.");
+                throw new IllegalArgumentException("Cannot convert " + s + " into a boolean.");
+            }
+        });
     }
 
     @Override
     public byte getByte(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-
-        if (string == null) {
-            return 0;
-        }
-        return string.getBytes()[0];
+        return getColumnIndexWithDefault(columnIndex, (byte)0, s -> s.getBytes()[0]);
     }
 
     @Override
     public short getShort(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return 0;
-        }
-
-        return Short.parseShort(string);
+        return getColumnIndexWithDefault(columnIndex, (short)0, Short::parseShort);
     }
 
     @Override
     public int getInt(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return 0;
-        }
-
-        return Integer.parseInt(string);
+        return getColumnIndexWithDefault(columnIndex, 0, Integer::parseInt);
     }
 
     @Override
     public long getLong(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return 0;
-        }
-
-        return Long.parseLong(string);
+        return getColumnIndexWithDefault(columnIndex, 0L, Long::parseLong);
     }
 
     @Override
     public float getFloat(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return 0;
-        }
-
-        return Float.parseFloat(string);
+        return getColumnIndexWithDefault(columnIndex, 0.0f, Float::parseFloat);
     }
 
     @Override
     public double getDouble(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return 0;
-        }
-
-        return Double.parseDouble(string);
+        return getColumnIndexWithDefault(columnIndex, 0.0, Double::parseDouble);
     }
 
     @Override
     public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-        return this.getBigDecimal(0);
+        return getColumnIndexWithDefault(columnIndex, BigDecimal.ZERO, BigDecimal::new);
     }
 
     @Override
     public byte[] getBytes(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return null;
-        }
-
-        return string.getBytes();
+        return getColumnIndexWithDefault(columnIndex, null, String::getBytes);
     }
 
     @Override
@@ -204,82 +219,82 @@ public class RedisResultSet implements ResultSet {
 
     @Override
     public String getString(String columnLabel) throws SQLException {
-        return this.getString(0);
+        return this.getString(findColumn(columnLabel));
     }
 
     @Override
     public boolean getBoolean(String columnLabel) throws SQLException {
-        return this.getBoolean(0);
+        return this.getBoolean(findColumn(columnLabel));
     }
 
     @Override
     public byte getByte(String columnLabel) throws SQLException {
-        return this.getByte(0);
+        return this.getByte(findColumn(columnLabel));
     }
 
     @Override
     public short getShort(String columnLabel) throws SQLException {
-        return this.getShort(0);
+        return this.getShort(findColumn(columnLabel));
     }
 
     @Override
     public int getInt(String columnLabel) throws SQLException {
-        return this.getInt(0);
+        return this.getInt(findColumn(columnLabel));
     }
 
     @Override
     public long getLong(String columnLabel) throws SQLException {
-        return this.getLong(0);
+        return this.getLong(findColumn(columnLabel));
     }
 
     @Override
     public float getFloat(String columnLabel) throws SQLException {
-        return this.getFloat(0);
+        return this.getFloat(findColumn(columnLabel));
     }
 
     @Override
     public double getDouble(String columnLabel) throws SQLException {
-        return this.getDouble(0);
+        return this.getDouble(findColumn(columnLabel));
     }
 
     @Override
     public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-        return this.getBigDecimal(0);
+        return this.getBigDecimal(findColumn(columnLabel));
     }
 
     @Override
     public byte[] getBytes(String columnLabel) throws SQLException {
-        return this.getBytes(0);
+        return this.getBytes(findColumn(columnLabel));
     }
 
     @Override
     public Date getDate(String columnLabel) throws SQLException {
-        return this.getDate(0);
+        return this.getDate(findColumn(columnLabel));
     }
 
     @Override
     public Time getTime(String columnLabel) throws SQLException {
-        return this.getTime(0);
+        return this.getTime(findColumn(columnLabel));
     }
 
     @Override
     public Timestamp getTimestamp(String columnLabel) throws SQLException {
-        return this.getTimestamp(0);
+        return this.getTimestamp(findColumn(columnLabel));
     }
 
     @Override
     public InputStream getAsciiStream(String columnLabel) throws SQLException {
-        return this.getAsciiStream(0);
+        return this.getAsciiStream(findColumn(columnLabel));
     }
 
     @Override
     public InputStream getUnicodeStream(String columnLabel) throws SQLException {
-        return this.getUnicodeStream(0);
+        return this.getUnicodeStream(findColumn(columnLabel));
     }
 
     @Override
     public InputStream getBinaryStream(String columnLabel) throws SQLException {
-        return this.getBinaryStream(0);
+        return this.getBinaryStream(findColumn(columnLabel));
     }
 
     @Override
@@ -299,23 +314,25 @@ public class RedisResultSet implements ResultSet {
 
     @Override
     public ResultSetMetaData getMetaData() throws SQLException {
-        return new RedisResultSetMetaData();
+        Map<Integer, ColumnConverter> map = new LinkedHashMap<>();
+        columnIndexes.forEach((k, i) -> map.put(i, i == DEFAULT_COLUMN_INDEX ? null : columnConverter));
+
+        return new RedisResultSetMetaData(map);
     }
 
     @Override
     public Object getObject(int columnIndex) throws SQLException {
-        LOGGER.log("getObject not implemented");
-        throw new SQLFeatureNotSupportedException("getObject not implemented");
+        return getColumnIndexWithDefault(columnIndex, null, o -> o);
     }
 
     @Override
     public Object getObject(String columnLabel) throws SQLException {
-        return this.getObject(0);
+        return this.getObject(findColumn(columnLabel));
     }
 
     @Override
     public int findColumn(String columnLabel) throws SQLException {
-        return 0;
+        return columnIndexes.getOrDefault(columnLabel, -1);
     }
 
     @Override
@@ -332,19 +349,12 @@ public class RedisResultSet implements ResultSet {
 
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-        this.checkClosed();
-
-        String string = this.getString(0);
-        if (string == null) {
-            return null;
-        }
-
-        return new BigDecimal(string);
+        return getBigDecimal(columnIndex, 0);
     }
 
     @Override
     public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-        return this.getBigDecimal(0);
+        return this.getBigDecimal(findColumn(columnLabel));
     }
 
     @Override
@@ -864,7 +874,7 @@ public class RedisResultSet implements ResultSet {
 
     @Override
     public URL getURL(String columnLabel) throws SQLException {
-        return this.getURL(0);
+        return this.getURL(findColumn(columnLabel));
     }
 
     @Override
@@ -1019,7 +1029,7 @@ public class RedisResultSet implements ResultSet {
 
     @Override
     public String getNString(String columnLabel) throws SQLException {
-        return this.getNString(0);
+        return this.getNString(findColumn(columnLabel));
     }
 
     @Override

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisResultSet.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisResultSet.java
@@ -21,6 +21,7 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -122,6 +123,9 @@ public class RedisResultSet implements ResultSet {
     @Override
     public String getString(int columnIndex) throws SQLException {
         LOGGER.log("getString(%s)", columnIndex);
+        if (columnIndex == -1) {
+            new RuntimeException(String.format("Results=%s, index=%s", Arrays.asList(result), columnIndex)).printStackTrace();
+        }
         return getColumnIndexWithDefault(columnIndex, null, String::toString);
     }
 
@@ -332,7 +336,7 @@ public class RedisResultSet implements ResultSet {
 
     @Override
     public int findColumn(String columnLabel) throws SQLException {
-        return columnIndexes.getOrDefault(columnLabel, -1);
+        return columnIndexes.getOrDefault(columnLabel, 1);
     }
 
     @Override

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisStatement.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisStatement.java
@@ -2,6 +2,7 @@ package com.itmuch.redis.jdbc;
 
 import java.sql.*;
 
+import com.itmuch.redis.jdbc.conf.Feature;
 import com.itmuch.redis.jdbc.conf.Op;
 
 public class RedisStatement implements Statement {
@@ -30,9 +31,9 @@ public class RedisStatement implements Statement {
         HashResultConverter hashConverter = HashResultConverter.COMMAND_CONVERTERS.get(op.getCommand());
 
         String[] result = this.redisClient.sendCommand(sql);
-        if (converter != null) {
+        if (converter != null && redisClient.getFeatureMap().get(Feature.EXTRA_COLUMN_CONVERSIONS)) {
             return new RedisResultSet(result, this, op.getParams(), converter);
-        } else if (hashConverter != null) {
+        } else if (hashConverter != null && redisClient.getFeatureMap().get(Feature.HASH_RESULT_CONVERSIONS)) {
           return new HashRedisResultSet(result, this, op.getParams(), hashConverter);
         } else {
             return new RedisResultSet(result, this);

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisStatement.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/RedisStatement.java
@@ -114,11 +114,7 @@ public class RedisStatement implements Statement {
 
     @Override
     public boolean execute(String sql) throws SQLException {
-        this.checkClosed();
-
-        String[] result = this.redisClient.sendCommand(sql);
-        this.resultSet = new RedisResultSet(result, this);
-
+        this.resultSet = executeQuery(sql);
         return true;
     }
 

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/Utils.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/Utils.java
@@ -36,11 +36,6 @@ public class Utils {
             allowedHintKeys = Hint.DEFAULT_ALLOWED_KEYS;
         }
 
-        // for IDEA database tool only
-        if (rawSql.contains("SELECT 'keep alive'")) {
-            return new Op(rawSql, null, "PING", new String[0]);
-        }
-
         // hints
         List<String> lines = new BufferedReader(new StringReader(rawSql))
                 .lines()
@@ -77,7 +72,19 @@ public class Utils {
 
         String sql = sb.toString();
 
-        String[] arr = sql.split(" ");
+        String[] arr = sql.split("\\s(?=(([^\"]*\"){2})*[^\"]*$)\\s*");
+        for (int i=1; i<arr.length; i++) { //remove surrounding quotes
+            String arg = arr[i];
+            if (arg != null && arg.length() > 1) {
+                char start = arg.charAt(0);
+                char end = arg.charAt(arg.length()-1);
+                if (start == end) {
+                    if (start == '\'' || start == '"') {
+                        arr[i] = arg.substring(1, arg.length()-1);
+                    }
+                }
+            }
+        }
 
         String commandString = arr[0];
 

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/Utils.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/Utils.java
@@ -31,6 +31,25 @@ public class Utils {
                 .collect(Collectors.toList());
     }
 
+    public static Map imapOf(Object... kv) {
+        return Collections.unmodifiableMap(mapOf(kv));
+    }
+
+    public static Map mapOf(Object... kv) {
+        if (kv.length % 2 != 0) {
+            throw new IllegalArgumentException("Key-value pairs must be even");
+        }
+        Map map = new LinkedHashMap();
+        for (int i = 0; i < kv.length; i++) {
+            if (i %2 ==0) {
+                Object k = kv[i];
+                Object v = kv[i+1];
+                map.put(k, v);
+            }
+        }
+        return map;
+    }
+
     public static Op parseSql(String rawSql, Set<String> allowedHintKeys) {
         if (allowedHintKeys == null || allowedHintKeys.size() == 0) {
             allowedHintKeys = Hint.DEFAULT_ALLOWED_KEYS;
@@ -86,7 +105,7 @@ public class Utils {
             }
         }
 
-        String commandString = arr[0];
+        String commandString = arr[0].toUpperCase();
 
         if (arr.length == 1) {
             return new Op(rawSql, hints, commandString, new String[0]);

--- a/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/conf/Feature.java
+++ b/redis-jdbc-driver-core/src/main/java/com/itmuch/redis/jdbc/conf/Feature.java
@@ -1,0 +1,26 @@
+package com.itmuch.redis.jdbc.conf;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang3.BooleanUtils;
+
+@AllArgsConstructor
+@Getter
+public enum Feature {
+    EXTRA_COLUMN_CONVERSIONS("extraColumnConversion", false),
+    HASH_RESULT_CONVERSIONS("hashResultConversion", false);
+    String propName;
+    boolean defaultValue;
+
+    public static Map<Feature, Boolean> fromProperties(Map properties) {
+        return Arrays.stream(values())
+                .collect(Collectors.toMap(e -> e, e -> {
+                    String value = properties.getOrDefault(e.propName, Boolean.toString(e.defaultValue)).toString();
+                    return BooleanUtils.toBoolean(value);
+                }));
+    }
+}

--- a/redis-jdbc-driver/pom.xml
+++ b/redis-jdbc-driver/pom.xml
@@ -21,6 +21,10 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>redis.clients</groupId>

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/AbstractRedisClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/AbstractRedisClient.java
@@ -74,7 +74,7 @@ public abstract class AbstractRedisClient implements RedisClient {
         } else if (originResult instanceof Collection) {
             List<byte[]> convertedList = Utils.convert((Collection<?>) originResult, new ArrayList<>());
             decodedResult = convertedList.stream()
-                    .map(SafeEncoder::encode)
+                    .map(AbstractRedisClient::nullSafeEncode)
                     .toArray(String[]::new);
         } else {
             LOGGER.log("cannot decode result. originResult = %s", originResult);
@@ -84,5 +84,9 @@ public abstract class AbstractRedisClient implements RedisClient {
         LOGGER.log("decode success. sql = %s, originResult = %s, decodedResult = %s",
                 sql, originResult, Utils.toList(decodedResult));
         return decodedResult;
+    }
+
+    private static String nullSafeEncode(byte[] bytes) {
+        return bytes == null ? null : SafeEncoder.encode(bytes);
     }
 }

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/AbstractRedisClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/AbstractRedisClient.java
@@ -2,6 +2,7 @@ package com.itmuch.redis.jdbc;
 
 import com.itmuch.redis.jdbc.conf.Hint;
 import com.itmuch.redis.jdbc.conf.Op;
+import org.apache.commons.lang3.StringUtils;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.SafeEncoder;
 
@@ -19,6 +20,16 @@ public abstract class AbstractRedisClient implements RedisClient {
     public String[] sendCommand(String sql) throws SQLException {
         try {
             Op op = Utils.parseSql(sql, null);
+
+            String firstParam = op.getParams().length == 0 ? null : op.getParams()[0];
+            if (op.getCommand().equals("USE") && firstParam != null) { //DB switch
+                select(Integer.valueOf(op.getParams()[0]));
+                return new String[]{"DB switched to " + op.getParams()[0]};
+            } else if (op.getCommand().equals("SELECT") && StringUtils.equalsIgnoreCase(firstParam, "DB_NAME()")) {
+                return new String[]{String.valueOf(this.getDbIndex())};
+            } else if (op.getCommand().equals("SELECT") && StringUtils.equalsIgnoreCase(firstParam, "keep_alive")) { // for IDEA database tool only
+                op = new Op(sql, null, "PING", new String[0]);
+            }
 
             Object result = this.sendCommand(op);
 

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/AbstractRedisClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/AbstractRedisClient.java
@@ -1,5 +1,6 @@
 package com.itmuch.redis.jdbc;
 
+import com.itmuch.redis.jdbc.conf.Feature;
 import com.itmuch.redis.jdbc.conf.Hint;
 import com.itmuch.redis.jdbc.conf.Op;
 import org.apache.commons.lang3.StringUtils;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public abstract class AbstractRedisClient implements RedisClient {
@@ -24,7 +26,7 @@ public abstract class AbstractRedisClient implements RedisClient {
             String firstParam = op.getParams().length == 0 ? null : op.getParams()[0];
             if (op.getCommand().equals("USE") && firstParam != null) { //DB switch
                 select(Integer.valueOf(op.getParams()[0]));
-                return new String[]{"DB switched to " + op.getParams()[0]};
+                return new String[]{op.getParams()[0]};
             } else if (op.getCommand().equals("SELECT") && StringUtils.equalsIgnoreCase(firstParam, "DB_NAME()")) {
                 return new String[]{String.valueOf(this.getDbIndex())};
             } else if (op.getCommand().equals("SELECT") && StringUtils.equalsIgnoreCase(firstParam, "keep_alive")) { // for IDEA database tool only

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/JedisRedisClusterClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/JedisRedisClusterClient.java
@@ -50,6 +50,11 @@ public class JedisRedisClusterClient extends AbstractRedisClient {
     }
 
     @Override
+    public int getDbIndex() throws SQLException {
+        return 0;
+    }
+
+    @Override
     public void close() {
         this.jedisCluster.close();
     }

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/JedisRedisClusterClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/JedisRedisClusterClient.java
@@ -1,19 +1,25 @@
 package com.itmuch.redis.jdbc.cluster;
 
 import com.itmuch.redis.jdbc.AbstractRedisClient;
+import com.itmuch.redis.jdbc.conf.Feature;
 import com.itmuch.redis.jdbc.conf.Hint;
 import com.itmuch.redis.jdbc.conf.Op;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @RequiredArgsConstructor
 public class JedisRedisClusterClient extends AbstractRedisClient {
     private final JedisCluster jedisCluster;
+
+    @Getter
+    private final Map<Feature, Boolean> featureMap;
 
     @Override
     protected Object sendCommand(Op op) {

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/JedisRedisClusterClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/JedisRedisClusterClient.java
@@ -55,6 +55,11 @@ public class JedisRedisClusterClient extends AbstractRedisClient {
     }
 
     @Override
+    public boolean hasMultiDb() {
+        return false;
+    }
+
+    @Override
     public void close() {
         this.jedisCluster.close();
     }

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/RedisClusterDriver.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/cluster/RedisClusterDriver.java
@@ -51,7 +51,7 @@ public class RedisClusterDriver implements Driver {
         );
         JedisRedisClusterClient jedisRedisClusterClient = new JedisRedisClusterClient(jedisCluster);
 
-        return new RedisConnection(jedisRedisClusterClient, "0", info);
+        return new RedisConnection(jedisRedisClusterClient, info);
     }
 
     @Override

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/conf/RedisClusterConnectionInfo.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/conf/RedisClusterConnectionInfo.java
@@ -5,8 +5,8 @@ import com.itmuch.redis.jdbc.Utils;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import redis.clients.jedis.BinaryJedisCluster;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -28,7 +28,7 @@ public class RedisClusterConnectionInfo extends BaseConnectionInfo {
         super((info));
         try {
             URI uri = new URI(rawUrl);
-            Object maxAttemptsString = info.getOrDefault("maxAttempts", BinaryJedisCluster.DEFAULT_MAX_ATTEMPTS);
+            Object maxAttemptsString = info.getOrDefault("maxAttempts", JedisCluster.DEFAULT_MAX_ATTEMPTS);
             int maxAttempts = Integer.parseInt(maxAttemptsString.toString());
 
             String query = uri.getQuery();

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/JedisRedisClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/JedisRedisClient.java
@@ -1,10 +1,13 @@
 package com.itmuch.redis.jdbc.redis;
 
 import java.sql.SQLException;
+import java.util.Map;
 
 import com.itmuch.redis.jdbc.AbstractRedisClient;
 import com.itmuch.redis.jdbc.Logger;
+import com.itmuch.redis.jdbc.conf.Feature;
 import com.itmuch.redis.jdbc.conf.Op;
+import lombok.Getter;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
@@ -15,9 +18,13 @@ public class JedisRedisClient extends AbstractRedisClient {
 
     private int dbIndex;
 
-    public JedisRedisClient(Jedis jedis, int initialDbIndex) {
+    @Getter
+    private final Map<Feature, Boolean> featureMap;
+
+    public JedisRedisClient(Jedis jedis, int initialDbIndex, Map<Feature, Boolean> featureMap) {
         this.jedis = jedis;
         this.dbIndex = initialDbIndex;
+        this.featureMap = featureMap;
     }
 
     @Override

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/JedisRedisClient.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/JedisRedisClient.java
@@ -1,5 +1,7 @@
 package com.itmuch.redis.jdbc.redis;
 
+import java.sql.SQLException;
+
 import com.itmuch.redis.jdbc.AbstractRedisClient;
 import com.itmuch.redis.jdbc.Logger;
 import com.itmuch.redis.jdbc.conf.Op;
@@ -11,8 +13,11 @@ public class JedisRedisClient extends AbstractRedisClient {
 
     private final Jedis jedis;
 
-    public JedisRedisClient(Jedis jedis) {
+    private int dbIndex;
+
+    public JedisRedisClient(Jedis jedis, int initialDbIndex) {
         this.jedis = jedis;
+        this.dbIndex = initialDbIndex;
     }
 
     @Override
@@ -42,6 +47,12 @@ public class JedisRedisClient extends AbstractRedisClient {
     @Override
     public synchronized void select(int dbIndex) {
         this.jedis.select(dbIndex);
+        this.dbIndex = dbIndex;
+    }
+
+    @Override
+    public int getDbIndex() throws SQLException {
+        return this.dbIndex;
     }
 
     @Override

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/RedisDriver.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/RedisDriver.java
@@ -59,7 +59,7 @@ public class RedisDriver implements Driver {
 //                jedis.clientSetname(clientName);
 //            }
 
-            return new RedisConnection(new JedisRedisClient(jedis), dbIndex + "", info);
+            return new RedisConnection(new JedisRedisClient(jedis, dbIndex), info);
         } catch (Exception e) {
             LOGGER.log("Cannot init RedisConnection %s", e);
             throw new SQLException("Cannot init RedisConnection", e);

--- a/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/RedisDriver.java
+++ b/redis-jdbc-driver/src/main/java/com/itmuch/redis/jdbc/redis/RedisDriver.java
@@ -1,12 +1,19 @@
 package com.itmuch.redis.jdbc.redis;
 
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Map;
+import java.util.Properties;
+
 import com.itmuch.redis.jdbc.Logger;
 import com.itmuch.redis.jdbc.RedisConnection;
+import com.itmuch.redis.jdbc.conf.Feature;
 import com.itmuch.redis.jdbc.conf.RedisConnectionInfo;
 import redis.clients.jedis.Jedis;
-
-import java.sql.*;
-import java.util.Properties;
 
 public class RedisDriver implements Driver {
     private final static Logger LOGGER = new Logger(RedisDriver.class);
@@ -59,7 +66,7 @@ public class RedisDriver implements Driver {
 //                jedis.clientSetname(clientName);
 //            }
 
-            return new RedisConnection(new JedisRedisClient(jedis, dbIndex), info);
+            return new RedisConnection(new JedisRedisClient(jedis, dbIndex, Feature.fromProperties(info)), info);
         } catch (Exception e) {
             LOGGER.log("Cannot init RedisConnection %s", e);
             throw new SQLException("Cannot init RedisConnection", e);
@@ -73,7 +80,10 @@ public class RedisDriver implements Driver {
 
     @Override
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
-        return new DriverPropertyInfo[0];
+        Map<Feature, Boolean> settings = Feature.fromProperties(info);
+        return settings.entrySet().stream().map(entry -> {
+            return new DriverPropertyInfo(entry.getKey().getPropName(), entry.getValue().toString());
+        }).toArray(DriverPropertyInfo[]::new);
     }
 
     @Override

--- a/redis-jdbc-driver/src/test/java/RedisTest.java
+++ b/redis-jdbc-driver/src/test/java/RedisTest.java
@@ -8,11 +8,14 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.IntStream;
 
+import com.itmuch.redis.jdbc.conf.Feature;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,7 +27,10 @@ public class RedisTest {
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
         Class.forName("com.itmuch.redis.jdbc.redis.RedisDriver");
 
-        Connection connection = DriverManager.getConnection("jdbc:redis://localhost:6379/0");
+        Properties props = new Properties();
+        Arrays.stream(Feature.values()).forEach(f -> props.put(f.getPropName(), true));
+        Connection connection = DriverManager.getConnection("jdbc:redis://localhost:6379/0",
+                                                            props);
         Statement statement = connection.createStatement();
 
         LOGGER.log("Initial schema is %s", connection.getSchema());
@@ -34,7 +40,7 @@ public class RedisTest {
         LOGGER.log("Test schema is %s", connection.getSchema());
 
         statement.execute("FLUSHDB");
-        statement.execute("SET a b");
+        statement.execute("SET 'a' \"b\"");
         ResultSet rs = statement.executeQuery("DBSIZE");
         rs.getMetaData().getColumnClassName(1);
         logResult(rs, "DB size");
@@ -43,6 +49,8 @@ public class RedisTest {
 
         rs = statement.executeQuery("TTL a");
         logResult(rs, "TTL result");
+
+
 
 //        statement.execute("set a b");
 //        ResultSet rs = statement.executeQuery("get a");

--- a/redis-jdbc-driver/src/test/java/RedisTest.java
+++ b/redis-jdbc-driver/src/test/java/RedisTest.java
@@ -1,15 +1,19 @@
 package com.itmuch.redis.jdbc;
 
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.sql.*;
-
 public class RedisTest {
-    private final static Logger LOGGER = new Logger(RedisStatement.class);
+    private final static Logger LOGGER = new Logger(RedisTest.class);
 
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
         Class.forName("com.itmuch.redis.jdbc.redis.RedisDriver");
@@ -17,12 +21,18 @@ public class RedisTest {
         Connection connection = DriverManager.getConnection("jdbc:redis://localhost:6379/0");
         Statement statement = connection.createStatement();
 
-        connection.setSchema("11");
-        ResultSet rs = statement.executeQuery("get a");
-        while (rs.next()) {
-            String string = rs.getString(0);
-            System.out.println(string);
-        }
+        LOGGER.log("Initial schema is %s", connection.getSchema());
+        statement.execute("USE    \"1\"   ");
+        LOGGER.log("First schema is %s", connection.getSchema());
+        statement.execute("USE  '11'");
+        LOGGER.log("Test schema is %s", connection.getSchema());
+
+        statement.execute("FLUSHDB");
+        statement.execute("SET a b");
+        ResultSet rs = statement.executeQuery("DBSIZE");
+        logResult(rs, "DB size");
+        rs = statement.executeQuery("get a");
+        logResult(rs, "Get result");
 
 //        statement.execute("set a b");
 //        ResultSet rs = statement.executeQuery("get a");
@@ -31,15 +41,11 @@ public class RedisTest {
 //        }
 //
         ResultSet resultSet = statement.executeQuery("keys *");
-        while (resultSet.next()) {
-            LOGGER.log(resultSet.getString(0));
-        }
+        logResult(resultSet, "Keys result");
 
         connection.setSchema("11");
         ResultSet resultSet2 = statement.executeQuery("set ab99 ab88");
-        while (resultSet2.next()) {
-            LOGGER.log(resultSet.getString(0));
-        }
+        logResult(resultSet, "set result");
 
         resultSet.close();
         statement.close();
@@ -64,6 +70,14 @@ public class RedisTest {
 //        while (rs4.next()) {
 //            LOGGER.log("rs4:" + rs4.getString(0));
 //        }
+    }
+
+    public static void logResult(ResultSet rs, String formattedMsg) throws SQLException {
+       int i = 0;
+       while (rs.next()) {
+           LOGGER.log(formattedMsg + "[" + i +"]=%s", rs.getString(1));
+           i++;
+       }
     }
 }
 


### PR DESCRIPTION
Few enhancements to support the querying using DBeaver. 
Try it out in IntelliJ as that might need more tweaking.

1. **Render timestamp in separate column called TIMESTAMP (TTL & PTTL)**

Before:

> RESULTS
> 1

After

> RESULTS | TIMESTAMP
> 1             |    2022-11-01....

2. **Render hash get operations**

> RESULTS
> key
> val

After

> KEY | VALUE
> key |    val

3. **Allow set/get of the schema via sql**
> USE ?

SET syntax conflicts with redis commands
> SELECT DB_NAME()


4. **Basic input support with spaces (single/double quotes) + command case-insensitiveness**
> SET 'my key' "my value"


PG syntax is too complicated with search_path

5. **DBeaver specific stuff**

Requires PreparedStatement, otherwise fails changing schema. Now it detects the schema from connection.
PreparedStatement impl is very bare to only support that use-case. Wish lombok had an annotation for this